### PR TITLE
Defer FDA food classification until after molecule detection

### DIFF
--- a/scripts/match_scoring.py
+++ b/scripts/match_scoring.py
@@ -871,7 +871,16 @@ def score_and_classify(features_df: pd.DataFrame, pnf_df: pd.DataFrame) -> pd.Da
         if not mask.any():
             continue
 
-        nonthera_here = mask & nonthera_mask
+        # Only fall back to the FDA food catalog when no molecule was identified in
+        # PNF, WHO, or the FDA drug mappings. This preserves the desired
+        # prioritization order (PNF → WHO → FDA drug → FDA food).
+        nonthera_here = (
+            mask
+            & nonthera_mask
+            & (~present_in_pnf)
+            & (~present_in_who)
+            & (~present_in_fda)
+        )
         others_mask = mask & (~nonthera_mask)
 
         if nonthera_here.any():


### PR DESCRIPTION
## Summary
- gate FDA food catalog classification behind checks for PNF, WHO, and FDA drug matches
- document the prioritization order directly in the scoring logic for clarity

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e08c4dc7d48327a7f414c8c3a879b0