### PR TITLE
Add reference match detail JSON column to match features

### DIFF
--- a/data_dictionary.md
+++ b/data_dictionary.md
@@ -27,6 +27,7 @@ table when validating new data or onboarding reviewers.
 | `did_brand_swap` | Indicates whether any FDA brand token was replaced with its generic. | [scripts/match_features.py](https://github.com/carlosresu/esoa/blob/main/scripts/match_features.py) | `True` even if the resulting text already contained the generic. |
 | `fda_dose_corroborated` | `True` when FDA metadata confirms the detected dose. | [scripts/match_features.py](https://github.com/carlosresu/esoa/blob/main/scripts/match_features.py) | Requires both a brand swap and matching FDA dose string. |
 | `fda_generics_list` | Canonical FDA generics surfaced during brand swaps. | [scripts/match_features.py](https://github.com/carlosresu/esoa/blob/main/scripts/match_features.py) | Serialized as a pipe-delimited string during export; informs `generic_final` fallback. |
+| `reference_match_details_json` | JSON string summarizing every raw-text token that matched PNF, WHO, FDA brand map, or FDA food references. | [scripts/match_features.py](https://github.com/carlosresu/esoa/blob/main/scripts/match_features.py) | Each entry lists the identified word, category, source reference, and dose/form/route metadata (or `none`/`not applicable`). |
 
 ## Dose, Route, and Form Parsing
 

--- a/scripts/match_outputs.py
+++ b/scripts/match_outputs.py
@@ -46,7 +46,7 @@ def _run_with_spinner(label: str, func: Callable[[], None]) -> float:
 OUTPUT_COLUMNS = [
     "esoa_idx","raw_text","parentheticals",
     "normalized","norm_compact","match_basis","match_basis_norm_basic",
-    "probable_brands","did_brand_swap","fda_dose_corroborated","fda_generics_list",
+    "probable_brands","did_brand_swap","fda_dose_corroborated","fda_generics_list","reference_match_details_json",
     "molecules_recognized","molecules_recognized_list","molecules_recognized_count",
     "dose_recognized","dosage_parsed_raw","dosage_parsed",
     "route_raw","form_raw","route_evidence_raw",


### PR DESCRIPTION
## Summary
- add a `reference_match_details_json` column that serializes every token in the raw text that matched PNF, WHO, FDA brand, or FDA food references
- capture FDA brand metadata and WHO display names so the JSON payload includes category, source, dose, form, and route information
- document the new column and include it in the exported outputs

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_b_68e09ae62ca083278df36e06165994d8