### PR TITLE
Add missing dependencies to requirements

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,9 +22,11 @@ It prepares raw CSVs, parses text into structured features, detects candidate ge
 
 **Python packages**
 - `numpy>=1.21`
+- `duckdb>=1.0`
 - `openpyxl>=3.1`
 - `pandas>=1.5`
 - `pyahocorasick>=2.0`
+- `pytest>=7.4`
 - `requests>=2.31`
 - `XlsxWriter>=3.0`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
+duckdb>=1.0
 numpy>=1.21
 openpyxl>=3.1
 pandas>=1.5
 pyahocorasick>=2.0
+pytest>=7.4
 requests>=2.31
 XlsxWriter>=3.0
 pyinstrument>=4.4


### PR DESCRIPTION
## Summary
- add duckdb and pytest to the Python dependency list
- update documentation to reflect the expanded requirements

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691d5007ee148327980d95ed4ee60f51)